### PR TITLE
Fix team storage and display security issues

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import type { IGame } from '../../shared/types/IGame';
+import ColoredTeam from './components/ColoredTeam.vue';
 import Grid from './components/Grid.vue';
 import Scoreboard from './components/Scoreboard.vue';
 import TeamSelector from './components/TeamSelector.vue';
-import { coloredTeam } from './lib/utils';
 import { store } from './lib/store';
 
 const buildTime = import.meta.env.VITE_BUILD_TIME;
@@ -27,7 +27,9 @@ onMounted(() => {
 <template>
 	<img src='/logo.png' alt='Tic Tac Toe Grid logo' />
 	<h1>Tic Tac Toe VS the World</h1>
-	<h2>You are playing with the <span v-html='coloredTeam(store.team)'></span> team</h2>
+	<h2>You are playing with the
+		<ColoredTeam :team='store.team' /> team
+	</h2>
 	<TeamSelector :x-players='store.game ? store.game.x.playerCount : 0'
 		:o-players='store.game ? store.game.o.playerCount : 0' v-if='store.team === null'></TeamSelector>
 	<div v-if='store.game'>

--- a/client/src/components/Cell.vue
+++ b/client/src/components/Cell.vue
@@ -1,6 +1,6 @@
 <script lang='ts' setup>
 import type { CellValue } from '@/shared/types/Grid';
-import { coloredTeam } from '@/lib/utils';
+import ColoredTeam from './ColoredTeam.vue';
 import { Transition } from 'vue';
 
 const props = defineProps<{
@@ -23,7 +23,7 @@ const keyDown = (e: KeyboardEvent) => {
 <template>
 	<div class='cell' :data-index='index' @click='emit("vote")' @keydown='keyDown' :tabindex='props.index + 1'>
 		<Transition name='new-cell'>
-			<div v-if='props.value !== null' v-html='coloredTeam(props.value)'></div>
+			<ColoredTeam :team='props.value' v-if='props.value !== null' />
 		</Transition>
 		<Transition name='vote-cell'>
 			<div class='voting-cell' v-if='props.voteActor && props.voteCount > 0'>

--- a/client/src/components/ColoredTeam.vue
+++ b/client/src/components/ColoredTeam.vue
@@ -1,0 +1,23 @@
+<script lang='ts' setup>
+import type { CellValue } from '@/shared/types/Grid';
+import { computed } from 'vue';
+
+const props = defineProps<{
+	team: CellValue;
+}>();
+const color = computed(() => {
+	if (props.team)
+		return { x: 'var(--team-x-color)', o: 'var(--team-o-color)' }[props.team]
+	else
+		return '';
+});
+</script>
+<template>
+	<span :style='{ color: color }'>{{ props.team || '' }}</span>
+</template>
+
+<style scoped>
+span {
+	text-transform: uppercase;
+}
+</style>

--- a/client/src/components/Scoreboard.vue
+++ b/client/src/components/Scoreboard.vue
@@ -1,7 +1,8 @@
 <script setup lang='ts'>
-import { coloredTeam, formatStatusMessage, playerCount } from '@/lib/utils';
+import { formatStatusMessage, playerCount } from '@/lib/utils';
 import { STEP_DURATION } from '../../../shared/constants';
 import type Status from '@/shared/types/Status';
+import ColoredTeam from './ColoredTeam.vue';
 import type TeamData from '@/shared/types/TeamData';
 import { computed, onMounted, ref } from 'vue';
 
@@ -29,12 +30,16 @@ onMounted(animateProgressBar);
 		</div>
 		<div class='scores'>
 			<div class='team' data-team='x'>
-				<div class='name' v-html='coloredTeam("x")'></div>
+				<div class='name'>
+					<ColoredTeam team='x' />
+				</div>
 				<div class='score'>{{ x.score }}</div>
 				<div class='player-count'>{{ playerCount(x.playerCount) }}</div>
 			</div>
 			<div class='team' data-team='o'>
-				<div class='name' v-html='coloredTeam("o")'></div>
+				<div class='name'>
+					<ColoredTeam team='o' />
+				</div>
 				<div class='score'>{{ o.score }}</div>
 				<div class='player-count'>{{ playerCount(o.playerCount) }}</div>
 			</div>

--- a/client/src/lib/store.ts
+++ b/client/src/lib/store.ts
@@ -1,7 +1,12 @@
 import type { CellValue } from '@/shared/types/Grid';
 import type { IGame } from '@/shared/types/IGame';
 import { reactive } from 'vue';
-const savedTeam = localStorage.getItem('3t_team') as 'x' | 'o' | null;
+let savedTeam = localStorage.getItem('3t_team') as 'x' | 'o' | null;
+if (savedTeam !== 'x' && savedTeam !== 'o') {
+	savedTeam = null;
+	localStorage.removeItem('3t_team');
+}
+
 export const store = reactive({
 	team: savedTeam,
 	game: null as IGame | null,

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,10 +1,5 @@
-import type { CellValue, Grid } from '@/shared/types/Grid';
+import type { Grid } from '@/shared/types/Grid';
 import type Status from '@/shared/types/Status';
-
-export function coloredTeam(team: CellValue): string {
-	if (team === null) return '';
-	return `<span class='colored-${team}'>${team.toUpperCase()}</span>`;
-}
 
 export function playerCount(count: number): string {
 	return count === 1 ? '1 player' : `${count} players`;
@@ -16,7 +11,7 @@ const SENTENCES = {
 	vote: 'Team $ is voting...',
 };
 export function formatStatusMessage(status: Status): string {
-	return SENTENCES[status.type].replace('$', coloredTeam(status.actor));
+	return SENTENCES[status.type].replace('$', status.actor.toUpperCase());
 }
 
 type WinningConfiguration =


### PR DESCRIPTION
This PR addresses issues raised in #1, preventing users from messing with localStorage to join non-existing teams and potentially inject malicious code in the page.

1. The `coloredTeam` function was replaced by a proper `ColoredTeam` Vue component, avoiding the usage of the unsafe `v-html` directive. This prevents any potential injection. 
2. The `store` initialization process was modified to check for the stored value and remove any forbidden value.

Thanks to @mattelothere for finding this issue.